### PR TITLE
feat: re-export type from webidl2

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,0 +1,15 @@
+/** Re-export types. */
+export * from "webidl2"
+
+/**
+ * Parses WebIDL content with Gecko-specific modifications.
+ * @param content The WebIDL content to parse.
+ * @param filename The filename (used for conditional tweaks).
+ */
+export function parse(content: string, filename: string): import("webidl2").IDLRootType[];
+
+/**
+ * Writes WebIDL content from AST and restores preprocessor directives.
+ * @param content The AST to write.
+ */
+export function write(content: import("webidl2").IDLRootType[]): string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.1",
       "license": "ISC",
       "dependencies": {
+        "@types/webidl2": "^24.4.3",
         "commander": "^10.0.1",
         "webidl2": "^24.4.1"
       },
@@ -280,6 +281,12 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
       "dev": true
+    },
+    "node_modules/@types/webidl2": {
+      "version": "24.4.3",
+      "resolved": "https://registry.npmjs.org/@types/webidl2/-/webidl2-24.4.3.tgz",
+      "integrity": "sha512-Rn7VaRM3TmzA3nPgwSOqC8MGzzY2W8J7f0IPEf2g5Ga0e6jCsuLRHF+O0gywp3gh37IE/quCWCbNDTwAdKeFKw==",
+      "license": "MIT"
     },
     "node_modules/@types/yargs": {
       "version": "17.0.24",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "type": "module",
   "exports": {
     ".": {
+      "types": "./lib/index.d.ts",
       "require": "./dist/index.cjs",
       "import": "./lib/index.js"
     }
@@ -22,6 +23,7 @@
     "webidl2": "^24.4.1"
   },
   "devDependencies": {
+    "@types/webidl2": "^24.4.3",
     "expect": "^29.5.0",
     "jsondiffpatch": "^0.4.1",
     "mocha": "^10.2.0",


### PR DESCRIPTION
Sets types for exported methods and re-exports all types from webidl2 to ensure that you don't need to install/import both packages.