### PR TITLE
fix: @types/webidl must be included as a regular dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,11 +19,11 @@
     }
   },
   "dependencies": {
+    "@types/webidl2": "^24.4.3",
     "commander": "^10.0.1",
     "webidl2": "^24.4.1"
   },
   "devDependencies": {
-    "@types/webidl2": "^24.4.3",
     "expect": "^29.5.0",
     "jsondiffpatch": "^0.4.1",
     "mocha": "^10.2.0",


### PR DESCRIPTION
In order to ensure that types are distributed with the package, they must be included as a regular dependency as opposed to dev dependencies.